### PR TITLE
Baseline ff fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,13 @@ jobs:
           command: |
             java -jar selenium-server-standalone-3.5.3.jar -log test-reports/selenium.log
           background: true
+      - run:
+          name: Install geckodriver
+          command: |
+            wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz &&
+            tar -xvzf geckodriver* &&
+            chmod +x geckodriver &&
+            sudo mv geckodriver /usr/local/bin
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - restore_cache:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,8 +32,6 @@ class AcceptanceTest(unittest.TestCase):
     def test_selenium_chrome(self):
         self._generic_test(webdriver.Chrome)
 
-    # mark this as a failure since I'm just going to get chrome going
-    @unittest.expectedFailure
     def test_selenium_firefox(self):
         firefox_options = FOptions()
         firefox_options.add_argument("--headless")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ Was going to use pytest, but why add another dependency.
 
 import unittest
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options as FOptions
 import selenium
 
 from app import app
@@ -14,12 +15,12 @@ class AcceptanceTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_false(self):
         assert False
-    
+
     def test_true(self):
         assert True
-    
-    def _generic_test(self, wdriver):
-        with wdriver() as driver:
+
+    def _generic_test(self, wdriver, options=None):
+        with wdriver(options=options) as driver:
             driver.get("http://localhost:5000")
             elem1 = driver.find_element_by_name(app.ELEM_NAME)
             assert elem1.text == app.WELCOME_TEXT
@@ -34,4 +35,6 @@ class AcceptanceTest(unittest.TestCase):
     # mark this as a failure since I'm just going to get chrome going
     @unittest.expectedFailure
     def test_selenium_firefox(self):
-        self._generic_test(webdriver.Firefox)
+        firefox_options = FOptions()
+        firefox_options.add_argument("--headless")
+        self._generic_test(webdriver.Firefox, firefox_options)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ Was going to use pytest, but why add another dependency.
 import unittest
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options as FOptions
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 import selenium
 
 from app import app
@@ -19,20 +20,23 @@ class AcceptanceTest(unittest.TestCase):
     def test_true(self):
         assert True
 
-    def _generic_test(self, wdriver, options=None):
-        with wdriver(options=options) as driver:
-            driver.get("http://localhost:5000")
-            elem1 = driver.find_element_by_name(app.ELEM_NAME)
-            assert elem1.text == app.WELCOME_TEXT
-            elem2 = driver.find_element_by_name(app.BUTTON_NAME)
-            elem2.click()
-            elem3 = driver.find_element_by_name(app.NEW_ELEM_NAME)
-            assert elem3.text == app.NEW_TEXT
+    def _generic_test(self, driver):
+        driver.get("http://localhost:5000")
+        elem1 = driver.find_element_by_name(app.ELEM_NAME)
+        assert elem1.text == app.WELCOME_TEXT
+        elem2 = driver.find_element_by_name(app.BUTTON_NAME)
+        elem2.click()
+        elem3 = driver.find_element_by_name(app.NEW_ELEM_NAME)
+        assert elem3.text == app.NEW_TEXT
 
     def test_selenium_chrome(self):
-        self._generic_test(webdriver.Chrome)
+        with webdriver.Chrome() as driver:
+            self._generic_test(driver)
 
     def test_selenium_firefox(self):
         firefox_options = FOptions()
         firefox_options.add_argument("--headless")
-        self._generic_test(webdriver.Firefox, firefox_options)
+        cap = DesiredCapabilities().FIREFOX
+        cap["marionette"] = False
+        with webdriver.Firefox(options=firefox_options, capabilities=cap) as driver:
+            self._generic_test(driver)


### PR DESCRIPTION
Fix running tests on firefox.

- Install geckodriver. The legacy browser images at certain points do not have it installed
- Run firefox with `--headless` option.
- [Set `marionette` to false](https://stackoverflow.com/questions/47782650/selenium-common-exceptions-sessionnotcreatedexception-message-unable-to-find-a/47785513)
